### PR TITLE
Fix bug in the displayImageFromFlickrBySearch method

### DIFF
--- a/FlickFinderComplete/FlickFinder/ViewController.swift
+++ b/FlickFinderComplete/FlickFinder/ViewController.swift
@@ -192,7 +192,7 @@ class ViewController: UIViewController {
         
         // create session and request
         let session = URLSession.shared
-        let request = URLRequest(url: flickrURLFromParameters(methodParameters))
+        let request = URLRequest(url: flickrURLFromParameters(methodParametersWithPageNumber))
         
         // create network request
         let task = session.dataTask(with: request) { (data, response, error) in


### PR DESCRIPTION
The displayImageFromFlickrBySearch has a parameter 'withPageNumber' that is used to get the pictures from a specific page. Due to an error in the code this parameter was not used in the executed request (so page 1 is selected).